### PR TITLE
Fix crash if /etc/writable/localtime is not a symlink

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+systemd (229-4ubuntu21.28ubports2) xenial; urgency=medium
+
+  * Fix crash if /etc/writable/localtime is not a symlink.
+
+ -- Ratchanan Srirattanamet <ratchanan@ubports.com>  Wed, 21 Oct 2020 01:44:52 +0700
+
 systemd (229-4ubuntu21.28ubports1) xenial; urgency=medium
 
   * Merge changes from xenial up to version 229-4ubuntu21.28.

--- a/debian/patches/0001-Fix-reading-of-localtime-link-on-readonly-systems.patch
+++ b/debian/patches/0001-Fix-reading-of-localtime-link-on-readonly-systems.patch
@@ -10,24 +10,26 @@ Subject: [PATCH] Fix reading of localtime link on readonly systems
 
 --- a/src/basic/time-util.c
 +++ b/src/basic/time-util.c
-@@ -1206,6 +1206,17 @@
-                 return 0;
-         }
+@@ -1186,6 +1186,19 @@
+         int r;
  
+         r = readlink_malloc("/etc/localtime", &t);
++
 +        /* Ubuntu Touch specific: handle path symlinked to /etc/writable. */
-+        e = path_startswith(t, "/etc/writable/");
-+        if (!e)
-+            e = path_startswith(t, "writable/");
-+        if (e) {
-+            free(t);
-+            r = readlink_malloc("/etc/writable/localtime", &t);
-+            if (r < 0)
-+                return r;
++        if (r == 0) {
++                e = path_startswith(t, "/etc/writable/");
++                if (!e)
++                        e = path_startswith(t, "writable/");
++                if (e) {
++                        free(t);
++                        t = NULL; /* Or it will double-free if the line below fails. */
++                        r = readlink_malloc("/etc/writable/localtime", &t);
++                }
 +        }
 +
-         e = path_startswith(t, "/usr/share/zoneinfo/");
-         if (!e)
-                 e = path_startswith(t, "../usr/share/zoneinfo/");
+         if (r < 0) {
+                 if (r != -EINVAL)
+                         return r; /* returns EINVAL if not a symlink */
 --- a/src/timedate/timedated.c
 +++ b/src/timedate/timedated.c
 @@ -119,7 +119,7 @@


### PR DESCRIPTION
I'm not sure how is it possible, but some devices have /etc/writable/
localtime as a file instead of a symlink. This should trigger Debian's
fallback but 1.) it didn't 2.) it crashes due to double-free.

Thus, we have to move our code up above the Debian fallback again.
Because the Debian fallback doesn't guard the unsuccessful first read
for us, we have to check it ourself. To fix double-free, we'll have to
set the variable we free to NULL again, or the auto-free mechanism will
double-free it if the suppose-to-overwrite call is not successful.

Fixes https://github.com/ubports/ubuntu-touch/issues/1585